### PR TITLE
Remove assumptions about alignment of inputs

### DIFF
--- a/armcortexm/1storder_masking/aes_encrypt.s
+++ b/armcortexm/1storder_masking/aes_encrypt.s
@@ -1005,8 +1005,14 @@ double_shiftrows:
 aes128_encrypt_ffs:
     push    {r0-r12,r14}
     sub.w   sp, #136
-    ldm     r2, {r4-r7}             // load the 1st 128-bit blocks in r4-r7
-    ldm     r3, {r8-r11}            // load the 2nd 128-bit blocks in r8-r11
+    ldr.w   r4, [r2]                // load the 1st 128-bit blocks in r4-r7
+    ldr     r5, [r2, #4]
+    ldr     r6, [r2, #8]
+    ldr     r7, [r2, #12]
+    ldr.w   r8, [r3]                // load the 2nd 128-bit blocks in r8-r11
+    ldr     r9, [r3, #4]
+    ldr     r10,[r3, #8]
+    ldr     r11,[r3, #12]
     bl      packing
     // ------------------ MASKING ------------------
     // generation of 1 random word
@@ -1119,8 +1125,14 @@ aes128_ffs_get_random_mask:
 aes128_encrypt_sfs:
     push    {r0-r12,r14}
     sub.w   sp, #136
-    ldm     r2, {r4-r7}             // load the 1st 128-bit blocks in r4-r7
-    ldm     r3, {r8-r11}            // load the 2nd 128-bit blocks in r8-r11
+    ldr.w   r4, [r2]                // load the 1st 128-bit blocks in r4-r7
+    ldr     r5, [r2, #4]
+    ldr     r6, [r2, #8]
+    ldr     r7, [r2, #12]
+    ldr.w   r8, [r3]                // load the 2nd 128-bit blocks in r8-r11
+    ldr     r9, [r3, #4]
+    ldr     r10,[r3, #8]
+    ldr     r11,[r3, #12]
     bl      packing
     // ------------------ MASKING ------------------
     // generation of 1 random word

--- a/armcortexm/1storder_masking/aes_keyschedule.s
+++ b/armcortexm/1storder_masking/aes_keyschedule.s
@@ -1470,8 +1470,14 @@ xor_columns_3:
 .align 2
 aes128_keyschedule_ffs:
     push    {r0-r12,r14}
-    ldm     r1, {r4-r7}             // load the 128-bit key in r4-r7
-    ldm     r1, {r8-r11}            // load the 128-bit key in r8-r11
+    ldr.w   r4, [r1]                // load the 128-bit key in r4-r7
+    ldr     r5, [r1, #4]
+    ldr     r6, [r1, #8]
+    ldr     r7, [r1, #12]
+    ldr.w   r8, [r1]                // load the 128-bit key in r8-r11
+    ldr     r9, [r1, #4]
+    ldr     r10,[r1, #8]
+    ldr     r11,[r1, #12]
     bl      packing                 // pack the master key
     // ------------------ MASKING ------------------
     // generation of 2 random words
@@ -1596,8 +1602,14 @@ ffs_get_random_mask:
 .align 2
 aes128_keyschedule_sfs:
     push    {r0-r12,r14}
-    ldm     r1, {r4-r7}             // load the 128-bit key in r4-r7
-    ldm     r1, {r8-r11}            // load the 128-bit key in r8-r11
+    ldr.w   r4, [r1]                // load the 128-bit key in r4-r7
+    ldr     r5, [r1, #4]
+    ldr     r6, [r1, #8]
+    ldr     r7, [r1, #12]
+    ldr.w   r8, [r1]                // load the 128-bit key in r8-r11
+    ldr     r9, [r1, #4]
+    ldr     r10,[r1, #8]
+    ldr     r11,[r1, #12]
     bl      packing                 // pack the master key
 
     // ------------------ MASKING ------------------

--- a/armcortexm/fixslicing/aes_encrypt.s
+++ b/armcortexm/fixslicing/aes_encrypt.s
@@ -476,8 +476,14 @@ double_shiftrows:
 aes128_encrypt_ffs:
     push    {r0-r12,r14}
     sub.w   sp, #56                 // allow space on the stack for tmp var
-    ldm     r2, {r4-r7}             // load the 1st 128-bit blocks in r4-r7
-    ldm     r3, {r8-r11}            // load the 2nd 128-bit blocks in r8-r11
+    ldr.w   r4, [r2]                // load the 1st 128-bit blocks in r4-r7
+    ldr     r5, [r2, #4]
+    ldr     r6, [r2, #8]
+    ldr     r7, [r2, #12]
+    ldr.w   r8, [r3]                // load the 2nd 128-bit blocks in r8-r11
+    ldr     r9, [r3, #4]
+    ldr     r10,[r3, #8]
+    ldr     r11,[r3, #12]
     ldr.w   r1, [sp, #112]          // load 'rkey' argument from the stack
     str.w   r1, [sp, #48]           // store it there for 'add_round_key'
     bl      packing                 // pack the 2 input blocks
@@ -515,8 +521,14 @@ aes128_encrypt_ffs:
     bl      unpacking               // unpack the internal state
     ldrd    r0, r1, [sp, #56]       // restore the addr to store the ciphertext
     add.w   sp, #64                 // restore the stack pointer
-    stm     r0, {r4-r7}             // store the ciphertext
-    stm     r1, {r8-r11}            // store the ciphertext
+    str.w   r4, [r0]                // store the ciphertext
+    str     r5, [r0, #4]
+    str     r6, [r0, #8]
+    str     r7, [r0, #12]
+    str.w   r8, [r1]                // store the ciphertext
+    str     r9, [r1, #4]
+    str     r10,[r1, #8]
+    str     r11,[r1, #12]
     pop     {r2-r12, r14}           // restore context
     bx      lr
 
@@ -536,8 +548,14 @@ aes128_encrypt_ffs:
 aes256_encrypt_ffs:
     push    {r0-r12,r14}
     sub.w   sp, #56                 // allow space on the stack for tmp var
-    ldm     r2, {r4-r7}             // load the 1st 128-bit blocks in r4-r7
-    ldm     r3, {r8-r11}            // load the 2nd 128-bit blocks in r8-r11
+    ldr.w   r4, [r2]                // load the 1st 128-bit blocks in r4-r7
+    ldr     r5, [r2, #4]
+    ldr     r6, [r2, #8]
+    ldr     r7, [r2, #12]
+    ldr.w   r8, [r3]                // load the 2nd 128-bit blocks in r8-r11
+    ldr     r9, [r3, #4]
+    ldr     r10,[r3, #8]
+    ldr     r11,[r3, #12]
     ldr.w   r1, [sp, #112]          // load 'rkey' argument from the stack
     str.w   r1, [sp, #48]           // store it there for 'add_round_key'
     bl      packing                 // pack the 2 input blocks
@@ -583,8 +601,14 @@ aes256_encrypt_ffs:
     bl      unpacking               // unpack the internal state
     ldrd    r0, r1, [sp, #56]       // restore the addr to store the ciphertext
     add.w   sp, #64                 // restore the stack pointer
-    stm     r0, {r4-r7}             // store the ciphertext
-    stm     r1, {r8-r11}            // store the ciphertext
+    str.w   r4, [r0]                // store the ciphertext
+    str     r5, [r0, #4]
+    str     r6, [r0, #8]
+    str     r7, [r0, #12]
+    str.w   r8, [r1]                // store the ciphertext
+    str     r9, [r1, #4]
+    str     r10,[r1, #8]
+    str     r11,[r1, #12]
     pop     {r2-r12, r14}           // restore context
     bx      lr
 
@@ -604,8 +628,14 @@ aes256_encrypt_ffs:
 aes128_encrypt_sfs:
     push    {r0-r12,r14}
     sub.w   sp, #56                 // allow space on the stack for tmp var
-    ldm     r2, {r4-r7}             // load the 1st 128-bit blocks in r4-r7
-    ldm     r3, {r8-r11}            // load the 2nd 128-bit blocks in r8-r11
+    ldr.w   r4, [r2]                // load the 1st 128-bit blocks in r4-r7
+    ldr     r5, [r2, #4]
+    ldr     r6, [r2, #8]
+    ldr     r7, [r2, #12]
+    ldr.w   r8, [r3]                // load the 2nd 128-bit blocks in r8-r11
+    ldr     r9, [r3, #4]
+    ldr     r10,[r3, #8]
+    ldr     r11,[r3, #12]
     ldr.w   r1, [sp, #112]          // load 'rkey' argument from the stack
     str.w   r1, [sp, #48]           // store it there for 'add_round_key'
     bl      packing                 // pack the 2 input blocks
@@ -647,8 +677,14 @@ aes128_encrypt_sfs:
     bl      unpacking               // unpack the internal state
     ldrd    r0, r1, [sp, #56]       // restore the addr to store the ciphertext
     add.w   sp, #64                 // restore the stack pointer
-    stm     r0, {r4-r7}             // store the ciphertext
-    stm     r1, {r8-r11}            // store the ciphertext
+    str.w   r4, [r0]                // store the ciphertext
+    str     r5, [r0, #4]
+    str     r6, [r0, #8]
+    str     r7, [r0, #12]
+    str.w   r8, [r1]                // store the ciphertext
+    str     r9, [r1, #4]
+    str     r10,[r1, #8]
+    str     r11,[r1, #12]
     pop     {r2-r12, r14}           // restore context
     bx      lr
 
@@ -668,8 +704,14 @@ aes128_encrypt_sfs:
 aes256_encrypt_sfs:
     push    {r0-r12,r14}
     sub.w   sp, #56                 // allow space on the stack for tmp var
-    ldm     r2, {r4-r7}             // load the 1st 128-bit blocks in r4-r7
-    ldm     r3, {r8-r11}            // load the 2nd 128-bit blocks in r8-r11
+    ldr.w   r4, [r2]                // load the 1st 128-bit blocks in r4-r7
+    ldr     r5, [r2, #4]
+    ldr     r6, [r2, #8]
+    ldr     r7, [r2, #12]
+    ldr.w   r8, [r3]                // load the 2nd 128-bit blocks in r8-r11
+    ldr     r9, [r3, #4]
+    ldr     r10,[r3, #8]
+    ldr     r11,[r3, #12]
     ldr.w   r1, [sp, #112]          // load 'rkey' argument from the stack
     str.w   r1, [sp, #48]           // store it there for 'add_round_key'
     bl      packing                 // pack the 2 input blocks
@@ -721,7 +763,13 @@ aes256_encrypt_sfs:
     bl      unpacking               // unpack the internal state
     ldrd    r0, r1, [sp, #56]       // restore the addr to store the ciphertext
     add.w   sp, #64                 // restore the stack pointer
-    stm     r0, {r4-r7}             // store the ciphertext
-    stm     r1, {r8-r11}            // store the ciphertext
+    str.w   r4, [r0]                // store the ciphertext
+    str     r5, [r0, #4]
+    str     r6, [r0, #8]
+    str     r7, [r0, #12]
+    str.w   r8, [r1]                // store the ciphertext
+    str     r9, [r1, #4]
+    str     r10,[r1, #8]
+    str     r11,[r1, #12]
     pop     {r2-r12, r14}           // restore context
     bx      lr

--- a/armcortexm/fixslicing/aes_keyschedule.s
+++ b/armcortexm/fixslicing/aes_keyschedule.s
@@ -672,8 +672,14 @@ loop_inv_sr_3:
 aes128_keyschedule_ffs:
     push    {r0-r12,r14}
     sub.w   sp, #56                 // allow space on the stack for tmp var
-    ldm     r1, {r4-r7}             // load the 128-bit key in r4-r7
-    ldm     r1, {r8-r11}            // load the 128-bit key in r8-r11
+    ldr.w   r4, [r1]                // load the 128-bit key in r4-r7
+    ldr     r5, [r1, #4]
+    ldr     r6, [r1, #8]
+    ldr     r7, [r1, #12]
+    ldr.w   r8, [r1]                // load the 128-bit key in r8-r11
+    ldr     r9, [r1, #4]
+    ldr     r10,[r1, #8]
+    ldr     r11,[r1, #12]
     bl      packing                 // pack the master key
     ldr.w   r0, [sp, #56]           // restore 'rkeys' address
     stm     r0, {r4-r11}            // store the packed master key in 'rkeys'
@@ -750,14 +756,26 @@ aes128_keyschedule_ffs:
 aes256_keyschedule_ffs:
     push    {r0-r12,r14}
     sub.w   sp, #56                 // allow space on the stack for tmp var
-    ldm     r1, {r4-r7}             // load the 128 first key bits in r4-r7
-    ldm     r1, {r8-r11}            // load the 128 first key bits in r8-r11
+    ldr.w   r4, [r1]                // load the 128 first key bits in r4-r7
+    ldr     r5, [r1, #4]
+    ldr     r6, [r1, #8]
+    ldr     r7, [r1, #12]
+    ldr.w   r8, [r1]                // load the 128 first key bits in r8-r11
+    ldr     r9, [r1, #4]
+    ldr     r10,[r1, #8]
+    ldr     r11,[r1, #12]
     bl      packing                 // pack the master key
     ldrd    r0,r1, [sp, #56]        // restore 'rkeys' and 'key' addresses
     stm     r0, {r4-r11}            // store the packed master key in 'rkeys'
     add.w   r1, #16                 // points to the 128 last bits of the key
-    ldm     r1, {r4-r7}             // load the 128 first key bits in r4-r7
-    ldm     r1, {r8-r11}            // load the 128 first key bits in r8-r11
+    ldr.w   r4, [r1]                // load the 128 first key bits in r4-r7
+    ldr     r5, [r1, #4]
+    ldr     r6, [r1, #8]
+    ldr     r7, [r1, #12]
+    ldr.w   r8, [r1]                // load the 128 first key bits in r8-r11
+    ldr     r9, [r1, #4]
+    ldr     r10,[r1, #8]
+    ldr     r11,[r1, #12]
     bl      packing                 // pack the master key
     ldr.w   r0, [sp, #56]           // restore 'rkeys' address
     add.w   r0, #32                 // points to the 128 last bits of the key
@@ -844,8 +862,14 @@ aes256_keyschedule_ffs:
 aes128_keyschedule_sfs:
     push    {r0-r12,r14}
     sub.w   sp, #56                 // allow space on the stack for tmp var
-    ldm     r1, {r4-r7}             // load the 128-bit key in r4-r7
-    ldm     r1, {r8-r11}            // load the 128-bit key in r8-r11
+    ldr.w   r4, [r1]                // load the 128-bit key in r4-r7
+    ldr     r5, [r1, #4]
+    ldr     r6, [r1, #8]
+    ldr     r7, [r1, #12]
+    ldr.w   r8, [r1]                // load the 128-bit key in r8-r11
+    ldr     r9, [r1, #4]
+    ldr     r10,[r1, #8]
+    ldr     r11,[r1, #12]
     bl      packing                 // pack the master key
     ldr.w   r0, [sp, #56]           // restore 'rkeys' address
     stm     r0, {r4-r11}            // store the packed master key in 'rkeys'
@@ -920,14 +944,26 @@ aes128_keyschedule_sfs:
 aes256_keyschedule_sfs:
     push    {r0-r12,r14}
     sub.w   sp, #56                 // allow space on the stack for tmp var
-    ldm     r1, {r4-r7}             // load the 128 first key bits in r4-r7
-    ldm     r1, {r8-r11}            // load the 128 first key bits in r8-r11
+    ldr.w   r4, [r1]                // load the 128 first key bits in r4-r7
+    ldr     r5, [r1, #4]
+    ldr     r6, [r1, #8]
+    ldr     r7, [r1, #12]
+    ldr.w   r8, [r1]                // load the 128 first key bits in r8-r11
+    ldr     r9, [r1, #4]
+    ldr     r10,[r1, #8]
+    ldr     r11,[r1, #12]
     bl      packing                 // pack the master key
     ldrd    r0,r1, [sp, #56]        // restore 'rkeys' and 'key' addresses
     stm     r0, {r4-r11}            // store the packed master key in 'rkeys'
     add.w   r1, #16                 // points to the 128 last bits of the key
-    ldm     r1, {r4-r7}             // load the 128 first key bits in r4-r7
-    ldm     r1, {r8-r11}            // load the 128 first key bits in r8-r11
+    ldr.w   r4, [r1]                // load the 128 first key bits in r4-r7
+    ldr     r5, [r1, #4]
+    ldr     r6, [r1, #8]
+    ldr     r7, [r1, #12]
+    ldr.w   r8, [r1]                // load the 128 first key bits in r8-r11
+    ldr     r9, [r1, #4]
+    ldr     r10,[r1, #8]
+    ldr     r11,[r1, #12]
     bl      packing                 // pack the master key
     ldr.w   r0, [sp, #56]           // restore 'rkeys' address
     add.w   r0, #32                 // points to the 128 last bits of the key

--- a/armcortexm/fixslicing/aes_keyschedule_lut.s
+++ b/armcortexm/fixslicing/aes_keyschedule_lut.s
@@ -318,7 +318,10 @@ inv_shiftrows_3:
 .align 2
 aes128_keyschedule_ffs_lut:
     push    {r1-r12,r14}
-    ldm     r1, {r4-r7}                 // load the encryption key
+    ldr.w   r4, [r1]                    // load the encryption key
+    ldr     r5, [r1, #4]
+    ldr     r6, [r1, #8]
+    ldr     r7, [r1, #12]
     adr     r3, AES_Sbox_compact        // load the sbox LUT address in r3
     movw    r2, #0x01                   // 1st const
     bl      aes128_keyschedule_rfunc    // 1st round
@@ -387,7 +390,10 @@ aes128_keyschedule_ffs_lut:
     bl      inv_shiftrows_1
     bl      packing_rkey
     ldr     r12, [sp]
-    ldm     r12, {r4-r7}
+    ldr.w   r4, [r12]                    // load the encryption key
+    ldr     r5, [r12, #4]
+    ldr     r6, [r12, #8]
+    ldr     r7, [r12, #12]
     mov     r8, r4
     mov     r9, r5
     mov     r10, r6
@@ -415,7 +421,10 @@ aes128_keyschedule_ffs_lut:
 .align 2
 aes256_keyschedule_ffs_lut:
     push    {r0-r12,r14}
-    ldm     r1, {r4-r11}                // load the encryption key
+    ldr.w   r4, [r1]                    // load the encryption key
+    ldr     r5, [r1, #4]
+    ldr     r6, [r1, #8]
+    ldr     r7, [r1, #12]
     adr     r3, AES_Sbox_compact        // load the sbox LUT address in r3
     movw    r2, #0x01                   // 1st const
     bl      aes256_keyschedule_rfunc_0  // 1st round
@@ -498,11 +507,17 @@ aes256_keyschedule_ffs_lut:
     bl      packing_rkey
     ldr     r12, [sp, #4]!
     add.w   r12, #16
-    ldm     r12, {r4-r7}
+    ldr.w   r4, [r12]
+    ldr     r5, [r12, #4]
+    ldr     r6, [r12, #8]
+    ldr     r7, [r12, #12]
     bl      inv_shiftrows_1
     bl      packing_rkey
     ldr     r12, [sp]
-    ldm     r12, {r4-r7}
+    ldr.w   r4, [r12]                    // load the encryption key
+    ldr     r5, [r12, #4]
+    ldr     r6, [r12, #8]
+    ldr     r7, [r12, #12]
     mov     r8, r4
     mov     r9, r5
     mov     r10, r6
@@ -530,7 +545,10 @@ aes256_keyschedule_ffs_lut:
 .align 2
 aes128_keyschedule_sfs_lut:
     push    {r1-r12,r14}
-    ldm     r1, {r4-r7}                 // load the encryption key
+    ldr.w   r4, [r1]                    // load the encryption key
+    ldr     r5, [r1, #4]
+    ldr     r6, [r1, #8]
+    ldr     r7, [r1, #12]
     adr     r3, AES_Sbox_compact        // load the sbox LUT address in r3
     movw    r2, #0x01                   // 1st const
     bl      aes128_keyschedule_rfunc    // 1st round
@@ -605,7 +623,10 @@ aes128_keyschedule_sfs_lut:
     bl      inv_shiftrows_1
     bl      packing_rkey
     ldr     r12, [sp]
-    ldm     r12, {r4-r7}
+    ldr.w   r4, [r12]                    // load the encryption key
+    ldr     r5, [r12, #4]
+    ldr     r6, [r12, #8]
+    ldr     r7, [r12, #12]
     mov     r8, r4
     mov     r9, r5
     mov     r10, r6
@@ -633,7 +654,10 @@ aes128_keyschedule_sfs_lut:
 .align 2
 aes256_keyschedule_sfs_lut:
     push    {r0-r12,r14}
-    ldm     r1, {r4-r11}                // load the encryption key
+    ldr.w   r4, [r1]                    // load the encryption key
+    ldr     r5, [r1, #4]
+    ldr     r6, [r1, #8]
+    ldr     r7, [r1, #12]
     adr     r3, AES_Sbox_compact        // load the sbox LUT address in r3
     movw    r2, #0x01                   // 1st const
     bl      aes256_keyschedule_rfunc_0  // 1st round
@@ -725,11 +749,17 @@ aes256_keyschedule_sfs_lut:
     bl      packing_rkey
     ldr     r12, [sp, #4]!
     add.w   r12, #16
-    ldm     r12, {r4-r7}
+    ldr.w   r4, [r12]
+    ldr     r5, [r12, #4]
+    ldr     r6, [r12, #8]
+    ldr     r7, [r12, #12]
     bl      inv_shiftrows_1
     bl      packing_rkey
     ldr     r12, [sp]
-    ldm     r12, {r4-r7}
+    ldr.w   r4, [r12]                    // load the encryption key
+    ldr     r5, [r12, #4]
+    ldr     r6, [r12, #8]
+    ldr     r7, [r12, #12]
     mov     r8, r4
     mov     r9, r5
     mov     r10, r6


### PR DESCRIPTION
I'm working on an integration of this AES implementation into https://github.com/mupq/pqm4. 
I ran into the following issue:

`ldm` and `stm` require the address to be aligned to 4 bytes.
As keys, plaintexts, and ciphertexts are `unsigned char*`, those are not guaranteed to be aligned in that way (actually, the way e.g., Kyber and NTRUPrime use AES, ciphertexts or keys are guaranteed to be unaligned.
I replaced the `ldm`/`stm` with normal `ldr`/`str` which don't require such alignment. It does increase the code size a bit, but hopefully that  does not impact performance too badly.

I've only tested the unmasked ffs implementations, but I tried to fix it in all implementations. Hopefully, I did not screw up. 